### PR TITLE
use ureq instead of reqwest

### DIFF
--- a/launchdarkly-server-sdk/Cargo.toml
+++ b/launchdarkly-server-sdk/Cargo.toml
@@ -21,7 +21,7 @@ futures = "0.3.24"
 lazy_static = "1.4.0"
 log = "0.4.14"
 lru = { version = "0.7.2", default_features = false }
-reqwest = { version = "0.11.6", default_features = false, features = ["rustls-tls", "blocking", "json"] }
+ureq = { version = "*", features = ["json", "charset", "rustls"] }
 ring = "0.16.20"
 launchdarkly-server-sdk-evaluation = "= 1.0.0-beta.5"
 serde = { version = "1.0.132", features = ["derive"] }
@@ -33,6 +33,7 @@ parking_lot = "0.12.0"
 tokio-stream = { version = "0.1.8", features = ["sync"] }
 moka = "0.7.1"
 uuid = {version = "1.0.0-alpha.1", features = ["v4"] }
+url = "2.3.1"
 
 [dev-dependencies]
 maplit = "1.0.1"
@@ -41,6 +42,7 @@ serde_json = { version = "1.0.73", features = ["preserve_order"] } # for determi
 tokio = { version = "1.21.2", features = ["macros", "time"] }
 test-case = "2.0.0"
 mockito = "0.31.0"
+http-types = "2.12"
 
 [[example]]
 name = "print_flags"

--- a/launchdarkly-server-sdk/src/lib.rs
+++ b/launchdarkly-server-sdk/src/lib.rs
@@ -60,6 +60,7 @@ mod reqwest;
 mod service_endpoints;
 mod stores;
 mod test_common;
+mod ureq;
 mod version;
 
 static LAUNCHDARKLY_EVENT_SCHEMA_HEADER: &str = "x-launchdarkly-event-schema";

--- a/launchdarkly-server-sdk/src/reqwest.rs
+++ b/launchdarkly-server-sdk/src/reqwest.rs
@@ -1,41 +1,41 @@
-use reqwest::StatusCode;
+// use reqwest::StatusCode;
 
-pub fn is_http_error_recoverable(status: StatusCode) -> bool {
-    if !status.is_client_error() {
-        return true;
-    }
+// pub fn is_http_error_recoverable(status: StatusCode) -> bool {
+//     if !status.is_client_error() {
+//         return true;
+//     }
 
-    matches!(
-        status,
-        StatusCode::BAD_REQUEST | StatusCode::REQUEST_TIMEOUT | StatusCode::TOO_MANY_REQUESTS
-    )
-}
+//     matches!(
+//         status,
+//         StatusCode::BAD_REQUEST | StatusCode::REQUEST_TIMEOUT | StatusCode::TOO_MANY_REQUESTS
+//     )
+// }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use reqwest::StatusCode;
-    use test_case::test_case;
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use reqwest::StatusCode;
+//     use test_case::test_case;
 
-    #[test_case("130.65331632653061", 130.65331632653061)]
-    #[test_case("130.65331632653062", 130.65331632653061)]
-    #[test_case("130.65331632653063", 130.65331632653064)]
-    fn json_float_serialization_matches_go(float_as_string: &str, expected: f64) {
-        let parsed: f64 = serde_json::from_str(float_as_string).unwrap();
-        assert_eq!(expected, parsed);
-    }
+//     #[test_case("130.65331632653061", 130.65331632653061)]
+//     #[test_case("130.65331632653062", 130.65331632653061)]
+//     #[test_case("130.65331632653063", 130.65331632653064)]
+//     fn json_float_serialization_matches_go(float_as_string: &str, expected: f64) {
+//         let parsed: f64 = serde_json::from_str(float_as_string).unwrap();
+//         assert_eq!(expected, parsed);
+//     }
 
-    #[test_case(StatusCode::CONTINUE, true)]
-    #[test_case(StatusCode::OK, true)]
-    #[test_case(StatusCode::MULTIPLE_CHOICES, true)]
-    #[test_case(StatusCode::BAD_REQUEST, true)]
-    #[test_case(StatusCode::UNAUTHORIZED, false)]
-    #[test_case(StatusCode::REQUEST_TIMEOUT, true)]
-    #[test_case(StatusCode::CONFLICT, false)]
-    #[test_case(StatusCode::TOO_MANY_REQUESTS, true)]
-    #[test_case(StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE, false)]
-    #[test_case(StatusCode::INTERNAL_SERVER_ERROR, true)]
-    fn can_determine_recoverable_errors(status: StatusCode, is_recoverable: bool) {
-        assert_eq!(is_recoverable, is_http_error_recoverable(status));
-    }
-}
+//     #[test_case(StatusCode::CONTINUE, true)]
+//     #[test_case(StatusCode::OK, true)]
+//     #[test_case(StatusCode::MULTIPLE_CHOICES, true)]
+//     #[test_case(StatusCode::BAD_REQUEST, true)]
+//     #[test_case(StatusCode::UNAUTHORIZED, false)]
+//     #[test_case(StatusCode::REQUEST_TIMEOUT, true)]
+//     #[test_case(StatusCode::CONFLICT, false)]
+//     #[test_case(StatusCode::TOO_MANY_REQUESTS, true)]
+//     #[test_case(StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE, false)]
+//     #[test_case(StatusCode::INTERNAL_SERVER_ERROR, true)]
+//     fn can_determine_recoverable_errors(status: StatusCode, is_recoverable: bool) {
+//         assert_eq!(is_recoverable, is_http_error_recoverable(status));
+//     }
+// }

--- a/launchdarkly-server-sdk/src/ureq.rs
+++ b/launchdarkly-server-sdk/src/ureq.rs
@@ -1,0 +1,15 @@
+pub fn is_http_success(status: u16) -> bool {
+    status < 300
+}
+
+pub fn is_http_client_error(status: u16) -> bool {
+    status >= 400 && status < 500
+}
+
+pub fn is_http_error_recoverable(status: u16) -> bool {
+    if !is_http_client_error(status) {
+        return true;
+    }
+
+    matches!(status, 400 | 408 | 429)
+}


### PR DESCRIPTION
Upgrading reqwest caused a bunch of issues when working with Tokio because of LaunchDarkly's architecture of having separate (non-async) threads do work in the background. ureq is better supported for blocking/ sync clients, so migrate to using that.

Testing: cargo test